### PR TITLE
Fix 404 link Create_the_Canvas_and_draw_on_it (kr)

### DIFF
--- a/files/ko/games/tutorials/2d_breakout_game_pure_javascript/index.html
+++ b/files/ko/games/tutorials/2d_breakout_game_pure_javascript/index.html
@@ -51,6 +51,6 @@ original_slug: Games/Tutorials/순수한_자바스크립트를_이용한_2D_벽�
 
 <h2 id="다음_단계">다음 단계</h2>
 
-<p>좋습니다, 이제 시작하도록 합시다. 첫 번째 챕터인 <a href="https://developer.mozilla.org/ko-KR/docs/Games/Tutorials/순수한_자바스크립트를_이용한_2D_벽돌깨기_게임/캔버스_생성과_그리기">캔버스 생성과 그리기</a> 부터 시작합니다.</p>
+<p>좋습니다, 이제 시작하도록 합시다. 첫 번째 챕터인 <a href="https://developer.mozilla.org/ko/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it">캔버스 생성과 그리기</a> 부터 시작합니다.</p>
 
 <p>{{Next("Games/Tutorials/순수한_자바스크립트를_이용한_2D_벽돌깨기_게임/캔버스_생성과_그리기")}} </p>


### PR DESCRIPTION
[This link](https://developer.mozilla.org/ko/docs/Games/Tutorials/%25EC%2588%259C%25EC%2588%2598%25ED%2595%259C_%25EC%259E%2590%25EB%25B0%2594%25EC%258A%25A4%25ED%2581%25AC%25EB%25A6%25BD%25ED%258A%25B8%25EB%25A5%25BC_%25EC%259D%25B4%25EC%259A%25A9%25ED%2595%259C_2D_%25EB%25B2%25BD%25EB%258F%258C%25EA%25B9%25A8%25EA%25B8%25B0_%25EA%25B2%258C%25EC%259E%2584/%25EC%25BA%2594%25EB%25B2%2584%25EC%258A%25A4_%25EC%2583%259D%25EC%2584%25B1%25EA%25B3%25BC_%25EA%25B7%25B8%25EB%25A6%25AC%25EA%25B8%25B0) can't access properly when I click below area.

https://developer.mozilla.org/ko/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript#%EB%8B%A4%EC%9D%8C_%EB%8B%A8%EA%B3%84

![image](https://user-images.githubusercontent.com/16266103/135876279-2ccd4d93-b3e0-4e0b-8798-70ca450f4977.png)

